### PR TITLE
Added filter out regex and force overwrite backup

### DIFF
--- a/Generate-Sysmon-config.ps1
+++ b/Generate-Sysmon-config.ps1
@@ -7,14 +7,22 @@
 # Merge-SysmonXMLConfiguration : The schema version of C:\sysmon-modular\sysmonconfig.xml () does not match that of the reference configuration: C:\sysmon-modular\baseconfig.xml (4.10) At line:1 
 #
 
+## Import "PSSysmonTools"
+## Import-Module .\PSSysmonTools.psm1
+
 $now=Get-Date -format "dd-MMM-yyyy-HH-mm"
 
 If((Test-Path .\sysmonconfig.xml)) {
   Write-Host "Existing sysmonconfig found, backing up."
-  Move-Item .\sysmonconfig.xml -Destination sysmonconfig-$now.xml
+  Move-Item .\sysmonconfig.xml -Destination sysmonconfig-$now.xml -Force
 } Else {
   Write-Host "No config found."
 }
 
+## Filter Output and Backup Files
+#sysmonconfig-16-Nov-2018-09-21.xml
+#sysmonconfig-\d{2}-\w{3}-\d{4}-\d{2}-\d{2}.xml
+#sysmonconfig.xml
+
 Write-Host "Generating new configuration..."
-Get-ChildItem -Path . -Filter *.xml -Recurse -ErrorAction SilentlyContinue | Merge-SysmonXMLConfiguration -ReferencePolicyPath .\baseconfig.xml | Out-File sysmonconfig.xml -Encoding UTF8 
+Get-ChildItem -Path . -Filter *.xml -Recurse -ErrorAction SilentlyContinue | Where {$_.Name -NotMatch "sysmonconfig(?:-\d{2}-\w{3}-\d{4}-\d{2}-\d{2})?.xml"} | Merge-SysmonXMLConfiguration -ReferencePolicyPath .\baseconfig.xml | Out-File sysmonconfig.xml -Encoding UTF8 


### PR DESCRIPTION
When running in current directory the Get-ChildItem command will pull it previous output and all backups. This can cause issues when updating existing files forcing the old files into the new output and not reflecting new changes.

Example: Ran script to generate config, made changed by removing some exclude filters, running generate config again doesn't update the exclude.

Workaround: purge any generated config file before running the Generate script.