### PR TITLE
Add Merge-SysmonXml.ps1

### DIFF
--- a/Merge-SysmonXml.ps1
+++ b/Merge-SysmonXml.ps1
@@ -1,0 +1,228 @@
+function Merge-AllSysmonXml
+{
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias('FullName')]
+        [string[]]$Path,
+
+        [switch]$AsString
+    )
+
+    begin {
+        $XmlDocs = @()
+    }
+
+    process{
+        foreach($FilePath in $Path){
+            $doc = [xml]::new()
+            Write-Verbose "Loading doc from $FilePath..."
+            $doc.Load($(Resolve-Path $FilePath))
+            $XmlDocs += $doc
+        }
+    }
+
+    end{
+        if($XmlDocs.Count -lt 2){
+            throw 'At least 2 sysmon configs expected'
+            return
+        }
+
+        $newDoc = $XmlDocs[0]
+        for($i = 1; $i -lt $XmlDocs.Count; $i++){
+            $newDoc = Merge-SysmonXml -Source $newDoc -Diff $XmlDocs[$i]
+        }
+
+        if($AsString){
+            try{
+                $sw = [System.IO.StringWriter]::new()
+                $xw = [System.Xml.XmlTextWriter]::new($sw)
+                $xw.Formatting = 'Indented'
+                $newDoc.WriteContentTo($xw)
+                return $sw.ToString()
+            }
+            finally{
+                $xw.Dispose()
+                $sw.Dispose()
+            }
+        }
+        else {
+            return $newDoc
+        }
+    }
+}
+
+function Merge-SysmonXml
+{
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'FromXmlDoc')]
+        [xml]$Source,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'FromXmlDoc')]
+        [xml]$Diff,
+
+        [switch]$AsString
+    )
+
+    $Rules = @{
+        ProcessCreate = @{
+            include = @()
+            exclude = @()
+        }
+        FileCreateTime = @{
+            include = @()
+            exclude = @()
+        }
+        NetworkConnect = @{
+            include = @()
+            exclude = @()
+        }
+        ProcessTerminate = @{
+            include = @()
+            exclude = @()
+        }
+        DriverLoad = @{
+            include = @()
+            exclude = @()
+        }
+        ImageLoad = @{
+            include = @()
+            exclude = @()
+        }
+        CreateRemoteThread = @{
+            include = @()
+            exclude = @()
+        }
+        RawAccessRead = @{
+            include = @()
+            exclude = @()
+        }
+        ProcessAccess = @{
+            include = @()
+            exclude = @()
+        }
+        FileCreate = @{
+            include = @()
+            exclude = @()
+        }
+        RegistryEvent = @{
+            include = @()
+            exclude = @()
+        }
+        FileCreateStreamHash = @{
+            include = @()
+            exclude = @()
+        }
+        PipeEvent = @{
+            include = @()
+            exclude = @()
+        }
+        WmiEvent = @{
+            include = @()
+            exclude = @()
+        }
+        DnsQuery = @{
+            include = @()
+            exclude = @()
+        }
+    }
+
+    $newDoc = [xml]@'
+<Sysmon schemaversion="4.22">
+<!-- Capture all hashes -->
+<HashAlgorithms>*</HashAlgorithms>
+<CheckRevocation/>
+<EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+        <!-- Event ID 1 == Process Creation. -->
+        <ProcessCreate onmatch="include"/>
+        <!-- Event ID 2 == File Creation Time. -->
+        <FileCreateTime onmatch="include"/>
+        <!-- Event ID 3 == Network Connection. -->
+        <NetworkConnect onmatch="include"/>
+        <!-- Event ID 5 == Process Terminated. -->
+        <ProcessTerminate onmatch="include"/>
+        <!-- Event ID 6 == Driver Loaded. -->
+        <DriverLoad onmatch="include"/>
+        <!-- Event ID 7 == Image Loaded. -->
+        <ImageLoad onmatch="include"/>
+        <!-- Event ID 8 == CreateRemoteThread. -->
+        <CreateRemoteThread onmatch="include"/>
+        <!-- Event ID 9 == RawAccessRead. -->
+        <RawAccessRead onmatch="include"/>
+        <!-- Event ID 10 == ProcessAccess. -->
+        <ProcessAccess onmatch="include"/>
+        <!-- Event ID 11 == FileCreate. -->
+        <FileCreate onmatch="include"/>
+        <!-- Event ID 12,13,14 == RegObject added/deleted, RegValue Set, RegObject Renamed. -->
+        <RegistryEvent onmatch="include"/>
+        <!-- Event ID 15 == FileStream Created. -->
+        <FileCreateStreamHash onmatch="include"/>
+        <!-- Event ID 17,18 == PipeEvent. Log Named pipe created & Named pipe connected -->
+        <PipeEvent onmatch="exclude"/>
+        <!-- Event ID 19,20,21, == WmiEvent. Log all WmiEventFilter, WmiEventConsumer, WmiEventConsumerToFilter activity-->
+        <WmiEvent onmatch="include"/>
+    </RuleGroup>
+</EventFiltering>
+</Sysmon>
+'@
+
+$mainRuleGroup = $newDoc.SelectSingleNode('//EventFiltering/RuleGroup')
+
+    foreach($key in $Rules.Keys){
+        foreach($config in $Source,$Diff){
+            foreach($rule in $config.SelectNodes("//RuleGroup/$Key"))
+            {
+                $clone = $rule.CloneNode($true)
+                $onmatch = ([System.Xml.XmlElement]$clone).GetAttribute('onmatch')
+                if(-not $onmatch){
+                    $onmatch = 'include'
+                }
+
+                $Rules[$key][$onmatch] += $clone
+            }
+        }
+
+        foreach($rule in $Rules[$key]['include']){
+            if($existing = $mainRuleGroup.SelectSingleNode("$key[@onmatch = 'include']")){
+                foreach($child in $rule.ChildNodes){
+                    $newNode = $newDoc.ImportNode($child, $true)
+                    $null = $existing.AppendChild($newNode)
+                }
+            }
+            else{
+                $newNode = $newDoc.ImportNode($rule, $true)
+                $null = $mainRuleGroup.AppendChild($newNode)
+            }
+        }
+
+        foreach($rule in $Rules[$key]['exclude']){
+            if($existing = $mainRuleGroup.SelectSingleNode("$key[@onmatch = 'exclude']")){
+                foreach($child in $rule.ChildNodes){
+                    $newNode = $newDoc.ImportNode($child, $true)
+                    $null = $existing.AppendChild($newNode)
+                }
+            }
+            else{
+                $newNode = $newDoc.ImportNode($rule, $true)
+                $null = $mainRuleGroup.AppendChild($newNode)
+            }
+        }
+    }
+
+    if($AsString){
+        try{
+            $sw = [System.IO.StringWriter]::new()
+            $xw = [System.Xml.XmlTextWriter]::new($sw)
+            $xw.Formatting = 'Indented'
+            $newDoc.WriteContentTo($xw)
+            return $sw.ToString()
+        }
+        finally{
+            $xw.Dispose()
+            $sw.Dispose()
+        }
+    }
+    else {
+        return $newDoc
+    }
+}


### PR DESCRIPTION
Initial version, limited error checking.

Merge-SysmonXml.ps1 contains 2 functions:

   - `Merge-AllSysmonXml` - takes a list of paths to xml files, loads them and merges all of them one by one
   - `Merge-SysmonXml` - takes two `[xml]` document objects, merges all valid rule nodes into a single document

```powershell
PS C:\> . .\Merge-SysmonXml.ps1
PS C:\> Merge-AllSysmonXml -Path (Get-ChildItem 1_process_creation -Filter *.xml).FullName -AsString
[new config xml appears here as a string]
```

TODO in a future update:
  - Error checking/handling on load
  - RuleGroup nesting validation
  - Support for merging named RuleGroups