### PR TITLE
DLL added to dectect tools like powershdll.exe

### DIFF
--- a/7_image_load/include_powershell.xml
+++ b/7_image_load/include_powershell.xml
@@ -4,6 +4,11 @@
       <ImageLoad onmatch="include">
     	  <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >system.management.automation.ni.dll</ImageLoaded>
 	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >system.management.automation.dll</ImageLoaded>
+	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >Microsoft.PowerShell.Commands.Diagnostics.dll</ImageLoaded>
+	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >Microsoft.PowerShell.Commands.Management.dll</ImageLoaded>
+	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >Microsoft.PowerShell.Commands.Utility.dll</ImageLoaded>
+	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >Microsoft.PowerShell.ConsoleHost.dll</ImageLoaded>
+	      <ImageLoaded name="technique_id=T1086,technique_name=PowerShell" condition="end with" >Microsoft.PowerShell.Security.dll</ImageLoaded>
       </ImageLoad>
 </RuleGroup>
 </EventFiltering>


### PR DESCRIPTION
Hi,
I had tried tools to bypass Powershell logging.
Tools used:
- https://github.com/p3nt4/PowerShdll
- https://github.com/leechristensen/UnmanagedPowerShell

When I tested the first one, I discovered that System.management.automation.dll was not imported in the  powershdll.exe process. 
However, the 5 following DLL were imported:
- Microsoft.PowerShell.Commands.Diagnostics.dll
- Microsoft.PowerShell.Commands.Management.dll
- Microsoft.PowerShell.Commands.Utility.dll
- Microsoft.PowerShell.ConsoleHost.dll
- Microsoft.PowerShell.Security.dll

When you look for processses that use these DLLs, you get only process which launch a Powerhsell session. As a result, you don't have any false positive !

I think it could be interesting to log the importation of these DLLs in the configuration file of Sysmon.

you can find the updated configuration file in this pull request

Have fun ! 