### PR TITLE
Added config for lsass file written to disk from task manager dumping…

### DIFF
--- a/11_file_create/include_taskmanager_lsass.xml
+++ b/11_file_create/include_taskmanager_lsass.xml
@@ -1,0 +1,10 @@
+<Sysmon schemaversion="4.22">
+   <EventFiltering>
+ <RuleGroup name="" groupRelation="and">
+      <FileCreate onmatch="include">
+			<TargetFilename condition="contains">\*lsass*.dmp\</TargetFilename> <!-- Capture LSASS dump from task manager -->
+			<Image condition="image">taskmgr.exe</Image>
+		</FileCreate>
+</RuleGroup>
+</EventFiltering>
+</Sysmon>


### PR DESCRIPTION
… process. This wasn't being detected by existing rules - tested on Server 2019 STD - 10.0.17763