### PR TITLE
Create exclude_teams.xml for Microsoft Teams

### DIFF
--- a/2_file_create_time/exclude_teams.xml
+++ b/2_file_create_time/exclude_teams.xml
@@ -1,0 +1,9 @@
+<Sysmon schemaversion="4.30">
+   <EventFiltering>
+ <RuleGroup name="" groupRelation="or">
+      <FileCreateTime onmatch="exclude">
+			<Image condition="end with">AppData\Local\Microsoft\Teams\current\Teams.exe</Image> <!--Teams constantly changes files-->      
+	  </FileCreateTime>
+</RuleGroup>
+</EventFiltering>
+</Sysmon>


### PR DESCRIPTION
Add new exclusion rule for Microsoft Teams.  It looks like Teams is just as bad about this as Chrome is, so I've added a new entry for Teams that is just like the Chrome rule.