### PR TITLE
Remove exclusion for autoruns registry keys

### DIFF
--- a/12_13_14_registry_event/exclude_windows_misc.xml
+++ b/12_13_14_registry_event/exclude_windows_misc.xml
@@ -3,8 +3,6 @@
  <RuleGroup name="" groupRelation="or">
       <RegistryEvent onmatch="exclude">
 			<!--SECTION: Windows:Misc-->
-			<TargetObject condition="end with">\CurrentVersion\Run</TargetObject> <!--Microsoft:Windows: Remove noise from the "\Windows\CurrentVersion\Run" wildcard-->
-			<TargetObject condition="end with">\CurrentVersion\RunOnce</TargetObject> <!--Microsoft:Windows: Remove noise from the "\Windows\CurrentVersion\Run" wildcard-->
 			<TargetObject condition="end with">\CurrentVersion\App Paths</TargetObject> <!--Microsoft:Windows: Remove noise from the "\Windows\CurrentVersion\App Paths" wildcard-->
 			<TargetObject condition="end with">\CurrentVersion\Image File Execution Options</TargetObject> <!--Microsoft:Windows: Remove noise from the "\Windows\CurrentVersion\Image File Execution Options" wildcard-->
 			<TargetObject condition="end with">\CurrentVersion\Shell Extensions\Cached</TargetObject> <!--Microsoft:Windows: Remove noise from the "\CurrentVersion\Shell Extensions\Cached" wildcard-->


### PR DESCRIPTION
The exclusion lines for \CurrentVersion\Run and \CurrentVersion\RunOnce were overwriting the inclusion for these in the include_autoruns_and_startup_keys.xml file

Removing these lines will allow these registry changes to be logged for detection in the registry run keys.