### PR TITLE
Updates Event ID 6 to default to logging all driver loads

### DIFF
--- a/Merge-SysmonXml.ps1
+++ b/Merge-SysmonXml.ps1
@@ -187,7 +187,8 @@ function Merge-SysmonXml
     </RuleGroup>
     <RuleGroup name="" groupRelation="or">
         <!-- Event ID 6 == Driver Loaded. -->
-        <DriverLoad onmatch="include"/>
+        <!--Default to log all and exclude only valid signed Microsoft or Intel drivers-->
+        <DriverLoad onmatch="exclude"/>
     </RuleGroup>
     <RuleGroup name="" groupRelation="or">
         <!-- Event ID 7 == Image Loaded. -->


### PR DESCRIPTION
From reading the original comments in the Event ID 6 excludes it seems as though the intention of the configuration would be to log every driver load into the kernel apart from those with a valid signature from Microsoft or Intel. However the current default in the merge script treats this as an include, meaning a blank include is present in the final merged configuration and from my understanding this means no events will be logged for this ID. 

Changed this to default to exclude so that everything is logged except for the manual exclusions already defined, which should fix the issue. Apologies if I've misunderstood the original intention here, in which case feel free to close this PR.