### PR TITLE
Stop clipboard logging

### DIFF
--- a/24_clipboard_change/exclude_all.xml
+++ b/24_clipboard_change/exclude_all.xml
@@ -1,5 +1,4 @@
 <Sysmon schemaversion="4.40">
-  <CaptureClipboard />
    <EventFiltering>
       <RuleGroup name="" groupRelation="or">
          <ClipboardChange onmatch="include">

--- a/Merge-SysmonXml.ps1
+++ b/Merge-SysmonXml.ps1
@@ -167,7 +167,6 @@ function Merge-SysmonXml
 <CheckRevocation/>
 <DnsLookup>False</DnsLookup> <!-- Disables lookup behavior, default is True (Boolean) -->
 <ArchiveDirectory>Sysmon</ArchiveDirectory><!-- Sets the name of the directory in the C:\ root where preserved files will be saved (String)-->
-<CaptureClipboard /><!--This enables capturing the Clipboard changes-->
 <EventFiltering>
     <RuleGroup name="" groupRelation="or">
         <!-- Event ID 1 == Process Creation. -->


### PR DESCRIPTION
In testing it looks as if leaving the CaptureClipboard flag within the config still results in the clipboard contents being archived in the C:\Sysmon directory, even though Event ID 24 is configured to currently exclude all entries from logging. This doesn't seem like it's intended, as it causes some of the same privacy concerns that led to the event being excluded from logging in the first place, and it isn't immediately obvious to end users that this will happen.

To resolve this I've removed the flag from both the exclude XML in the Event ID 24 folder, and from the base XML in the merge script, which seems to resolve the issue. 

If the intention was to leave the archiving functionality enabled with only the logging disabled please feel free to ignore or close this PR, but it may be worth documenting the current behaviour then.