### PR TITLE
Fixed dns exclusion typos

### DIFF
--- a/22_dns_query/exclude_cdn_networks.xml
+++ b/22_dns_query/exclude_cdn_networks.xml
@@ -5,7 +5,7 @@
       <DnsQuery onmatch="exclude">
 			<QueryName condition="end with">.akadns.net</QueryName> <!--AkamaiCDN, extensively used by Microsoft | Microsoft default exclusion-->
 			<QueryName condition="end with">.netflix.com</QueryName>
-			<QueryName condition="end with">aspnetcdn.com</QueryName> <!--Microsoft [ https://docs.microsoft.com/en-us/aspnet/ajax/cdn/overview ]-->
+			<QueryName condition="end with">.aspnetcdn.com</QueryName> <!--Microsoft [ https://docs.microsoft.com/en-us/aspnet/ajax/cdn/overview ]-->
 			<QueryName condition="is">ajax.googleapis.com</QueryName>
 			<QueryName condition="is">cdnjs.cloudflare.com</QueryName> <!--Cloudflare: Hosts popular javascript libraries-->
 			<QueryName condition="is">fonts.googleapis.com</QueryName> <!--Google fonts-->

--- a/22_dns_query/exclude_ocsp_domains.xml
+++ b/22_dns_query/exclude_ocsp_domains.xml
@@ -7,10 +7,12 @@
 		<QueryName condition="end with">.globalsign.net</QueryName>
 		<QueryName condition="is">msocsp.com</QueryName> <!--Microsoft:OCSP-->
 		<QueryName condition="is">ocsp.msocsp.com</QueryName> <!--Microsoft:OCSP-->
-		<QueryName condition="end with">pki.goog</QueryName>
-		<QueryName condition="is">ocsp.godaddy.com</QueryName>
-		<QueryName condition="end with">amazontrust.com</QueryName>
-		<QueryName condition="is">ocsp.sectigo.com</QueryName>
+        	<QueryName condition="is">pki.goog</QueryName>
+        	<QueryName condition="end with">.pki.goog</QueryName>
+	      	<QueryName condition="is">ocsp.godaddy.com</QueryName>
+        	<QueryName condition="is">amazontrust.com</QueryName>
+        	<QueryName condition="end with">.amazontrust.com</QueryName>
+	      	<QueryName condition="is">ocsp.sectigo.com</QueryName>
 		<QueryName condition="is">pki-goog.l.google.com</QueryName>
 		<QueryName condition="end with">.usertrust.com</QueryName>
 		<QueryName condition="is">ocsp.comodoca.com</QueryName>


### PR DESCRIPTION
Fixed a couple of small typos where a . was missing from a domain used alongside the "end with" condition. This may allow attackers to bypass logging by registering a domain that fits the current conditions, e.g. bad-actor-aspnetcdn.com would currently not be logged.

This is a pretty minor issue, but one that's hopefully worth cleaning up for the amount of effort it took. FWIW I think some of the issues are also present in Swift's config also, so may be inherited.