### PR TITLE
Added other named pipe used by Cobalt Strike.

### DIFF
--- a/17_18_pipe_event/include_cobaltstrike.xml
+++ b/17_18_pipe_event/include_cobaltstrike.xml
@@ -3,10 +3,13 @@
     <RuleGroup name="" groupRelation="or">
       <PipeEvent onmatch="include">
         <Rule groupRelation="and">
-        <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\msse-</PipeName>        <!-- default cobalt strike pipe name-->
-        <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="end with">\-server</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="begin with">\msse-</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="end with">\-server</PipeName>        <!-- default cobalt strike pipe name-->
         </Rule>
         <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\msagent_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="begin with">\postex_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1021.004,technique_name=Remote Services: SSH" condition="begin with">\postex_ssh_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\status_</PipeName>        <!-- default cobalt strike pipe name-->
       </PipeEvent>
     </RuleGroup>
   </EventFiltering>

--- a/17_18_pipe_event/include_cobaltstrike.xml
+++ b/17_18_pipe_event/include_cobaltstrike.xml
@@ -3,8 +3,8 @@
     <RuleGroup name="" groupRelation="or">
       <PipeEvent onmatch="include">
         <Rule groupRelation="and">
-        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="begin with">\msse-</PipeName>        <!-- default cobalt strike pipe name-->
-        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="end with">\-server</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\msse-</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="end with">\-server</PipeName>        <!-- default cobalt strike pipe name-->
         </Rule>
         <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\msagent_</PipeName>        <!-- default cobalt strike pipe name-->
         <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="begin with">\postex_</PipeName>        <!-- default cobalt strike pipe name-->


### PR DESCRIPTION
Hi,
According Cobalt Strike documentation (https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/) and some test especial we have other named pipe related to Cobalt Strike.