### PR TITLE
Adding module load monitoring for vaultcli.dll

### DIFF
--- a/7_image_load/exclude_vaulcmd_vaultcli.xml
+++ b/7_image_load/exclude_vaulcmd_vaultcli.xml
@@ -1,0 +1,12 @@
+<Sysmon schemaversion="4.30">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ImageLoad onmatch="exclude">
+        <Rule groupRelation="and">
+          <Image condition="is">C:\Windows\System32\VaultCmd.exe</Image>
+          <OriginalFileName condition="is">vaultcli.dll</OriginalFileName>
+        </Rule>
+      </ImageLoad>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>

--- a/7_image_load/include_vaultcli.xml
+++ b/7_image_load/include_vaultcli.xml
@@ -1,0 +1,9 @@
+<Sysmon schemaversion="4.30">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ImageLoad onmatch="include">
+        <ImageLoaded name="technique_id=T1555,technique_name=Credentials from Password Stores" condition="end with">vaultcli.dll</ImageLoaded>
+      </ImageLoad>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
Vaultcli.dll module may be used by malware for credential harvesting. Excluding from monitoring windows built-in command line utility vaultcmd.exe.

Further examples [on this post](https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16) by David French.

