### PR TITLE
Adding exclusion for ID 10 for PowerToys

### DIFF
--- a/10_process_access/exclude_microsoft_powertoys.xml
+++ b/10_process_access/exclude_microsoft_powertoys.xml
@@ -1,0 +1,8 @@
+<Sysmon schemaversion="4.60">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessAccess onmatch="exclude">
+        <SourceImage condition="is">C:\Program Files\PowerToys\modules\KeyboardManager\KeyboardManagerEngine\PowerToys.KeyboardManagerEngine.exe</SourceImage>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
Microsoft PowerToys Keyboard Manager process taps into several processes included elsewhere in event code 10. (Over 300k events on one host over 7 days.)

![image](https://user-images.githubusercontent.com/56129551/129125506-1673180f-52f6-4732-955a-258970814220.png)
