### PR TITLE
Updated ATT&CK Navigator link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ I started a series of blog posts covering this repo;
 ## Mitre ATT&CK
 
 I strive to map all configurations to the ATT&CK framework whenever Sysmon is able to detect it.
-A current ATT&CK navigator export of all linked configurations is found [here](attack_matrix/Sysmon-modular.json) and can be viewed [here](https://mitre.github.io/attack-navigator/enterprise/#layerURL=https%3A%2F%2Fraw.githubusercontent.com%2Folafhartong%2Fsysmon-modular%2Fmaster%2Fattack_matrix%2FSysmon-modular.json&scoring=false&clear_annotations=false)
+A current ATT&CK navigator export of all linked configurations is found [here](attack_matrix/Sysmon-modular.json) and can be viewed [here](https://mitre-attack.github.io/attack-navigator/enterprise/#layerURL=https%3A%2F%2Fraw.githubusercontent.com%2Folafhartong%2Fsysmon-modular%2Fmaster%2Fattack_matrix%2FSysmon-modular.json&scoring=false&clear_annotations=false)
 ![Mapping](attack_matrix/sysmon-modular.png)
 
 ## Required actions


### PR DESCRIPTION
The current link (mitre.github.io) will not automatically open the sysmon-modular layer. Updating the target to mitre-attack.github.io resolves the link issue.