### PR TITLE
Added access mask used by Metasploit's migrate

### DIFF
--- a/10_process_access/include_possible_dll_injection.xml
+++ b/10_process_access/include_possible_dll_injection.xml
@@ -4,7 +4,7 @@
       <ProcessAccess onmatch="include">
         <Rule groupRelation="and">
           <CallTrace name="technique_id=T1055.001,technique_name=Dynamic-link Library Injection" condition="contains all">C:\Windows\SYSTEM32\ntdll.dll;C:\Windows\System32\kernelbase.dll;UNKNOWN</CallTrace>          <!--@darkquassar-->
-          <GrantedAccess name="technique_id=T1055.001,technique_name=Dynamic-link Library Injection" condition="contains any">0x1F0FFF;0x1F1FFF;0x143A;0x1410;0x1010;0x1F2FFF;0x1F3FFF;0x1FFFFF</GrantedAccess>
+          <GrantedAccess name="technique_id=T1055.001,technique_name=Dynamic-link Library Injection" condition="contains any">0x1F0FFF;0x1F1FFF;0x143A;0x1410;0x1010;0x1F2FFF;0x1F3FFF;0x1FFFFF;0x147A</GrantedAccess>
         </Rule>
       </ProcessAccess>
     </RuleGroup>


### PR DESCRIPTION
This is from my process injection test.

0x147A = {
PROCESS_CREATE_THREAD, 
PROCESS_DUP_HANDLE, 
PROCESS_QUERY_LIMITED_INFORMATION, 
PROCESS_QUERY_INFORMATION, 
PROCESS_VM_OPERATION, 
PROCESS_VM_READ, 
PROCESS_VM_WRITE
}

TLDR; Metasploit's migrate -> UNKNOWN (call_trace) + 0x147A

I am not seeing any FPs from my side so far.