### PR TITLE
Creating process access exclusions for metricbeat, file creation excl…

### DIFF
--- a/10_process_access/exclude_elastic.xml
+++ b/10_process_access/exclude_elastic.xml
@@ -1,0 +1,9 @@
+<Sysmon schemaversion="4.60">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessAccess onmatch="exclude">
+        <SourceImage condition="contains all">C:\Program Files\Elastic\Agent\data\;\install\metricbeat.exe</SourceImage> <!--Very Noisy-->
+      </ProcessAccess>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>

--- a/11_file_create/exclude_elastic_logs.xml
+++ b/11_file_create/exclude_elastic_logs.xml
@@ -1,0 +1,13 @@
+<Sysmon schemaversion="4.30">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileCreate onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="begin with">C:\Program Files\Elastic\Agent\data\</Image> <!--The executables in the Elastic Agent directory log to ndjson and json files, creating much noise -->
+               <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.json</TargetFilename>
+               <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.ndjson</TargetFilename>
+            </Rule>
+         </FileCreate>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
I've added two exclusion files for elastic agent-related entries.

First are process access events by metricbeat.exe.  For me, compared to the default config ([default - sysmonconfig.xml](https://raw.githubusercontent.com/olafhartong/sysmon-modular/master/sysmonconfig.xml)), this would remove about 3.6 million events created by Metric Beat over the last 24 hour period.

Second is the .json and .ndjson files in C:\Program Files\Elastic\Agent\data\ . These are created pretty frequently, depending on how logging it set up and has created over seven thousand events in a 24 hour period.   To avoid tampering, there is also a check that the source image is also in C:\Program Files\Elastic\Agent\data\ .