### PR TITLE
Additional Elastic-related exclusions

### DIFF
--- a/10_process_access/exclude_elastic.xml
+++ b/10_process_access/exclude_elastic.xml
@@ -2,7 +2,7 @@
   <EventFiltering>
     <RuleGroup name="" groupRelation="or">
       <ProcessAccess onmatch="exclude">
-        <SourceImage condition="contains all">C:\Program Files\Elastic\Agent\data\;\install\metricbeat.exe</SourceImage> <!--Very Noisy-->
+        <SourceImage condition="contains all">C:\Program Files\Elastic\Agent\data\;\metricbeat.exe</SourceImage> <!--Very Noisy-->
       </ProcessAccess>
     </RuleGroup>
   </EventFiltering>

--- a/10_process_access/exclude_elastic.xml
+++ b/10_process_access/exclude_elastic.xml
@@ -1,0 +1,9 @@
+<Sysmon schemaversion="4.60">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessAccess onmatch="exclude">
+        <SourceImage condition="contains all">C:\Program Files\Elastic\Agent\data\;\install\metricbeat.exe</SourceImage> <!--Very Noisy-->
+      </ProcessAccess>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>

--- a/11_file_create/exclude_elastic_logs.xml
+++ b/11_file_create/exclude_elastic_logs.xml
@@ -3,8 +3,13 @@
       <RuleGroup name="" groupRelation="or">
          <FileCreate onmatch="exclude">
             <Rule groupRelation="and">
-               <Image condition="begin with">C:\Program Files\Elastic\Agent\data\</Image> <!--The executables in the Elastic Agent directory log to ndjson and json files, creating much noise -->
-               <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.json</TargetFilename>
+               <!--Elasticcreates last-document-id.json as state file for the endpoint agent-->
+               <Image condition="is">C:\Program Files\Elastic\Endpoint\elastic-endpoint.exe</Image> 
+               <TargetFilename condition="is">C:\Program Files\Elastic\Endpoint\state\last-document-id.json</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <!--The executables in the Elastic Agent directory log to ndjson acreating much noise -->
+               <Image condition="begin with">C:\Program Files\Elastic\Agent\data\</Image> 
                <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.ndjson</TargetFilename>
             </Rule>
          </FileCreate>

--- a/11_file_create/exclude_elastic_logs.xml
+++ b/11_file_create/exclude_elastic_logs.xml
@@ -1,0 +1,13 @@
+<Sysmon schemaversion="4.30">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileCreate onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="begin with">C:\Program Files\Elastic\Agent\data\</Image> <!--The executables in the Elastic Agent directory log to ndjson and json files, creating much noise -->
+               <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.json</TargetFilename>
+               <TargetFilename condition="contains all">C:\Program Files\Elastic\Agent\data\;.ndjson</TargetFilename>
+            </Rule>
+         </FileCreate>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
I've added two exclusion files for elastic-related entries.

**_10_process_access/exclude_elastic.xml_** excludes process access events for metricbeat.exe  In my own use case a single agent was generating about 3.8 million events over a 24 hour period when using the default sysmonconfig.xml  This eliminates all of those. For extra security it only excludes the event if the source is in the Elastic Agent directory under Program Files AND is metricbeat.exe, allowing malicious files with the same name to be captured.

**_11_file_create/exclude_elastic_logs.xml_** excludes last-document-id.json created by elastic-endpoint.exe. This file is created every few minutes as a state file. It generated a lot of entries without real value.  Also excluded are any of the .ndjson files created in the Elastic Agent Directory as these are just the log files created by the agent. Again, the writes aren't really particularly useful to know about and are very noisy. 