### PR TITLE
Display file name when XML load fails

### DIFF
--- a/Merge-SysmonXml.ps1
+++ b/Merge-SysmonXml.ps1
@@ -146,6 +146,9 @@ function Merge-AllSysmonXml
             $doc = [xml]::new()
             Write-Verbose "Loading doc from '$FilePath'..."
             $doc.Load($FilePath)
+            if(!$?){
+                Write-Error "Could not load file '$FilePath'"
+            }
             if(-not $PreserveComments){
                 Write-Verbose "Stripping comments for '$FilePath'"
                 $commentNodes = $doc.SelectNodes('//comment()')


### PR DESCRIPTION
Merge-AllSysmonXml will display an error if the XML file load fails. If the error is due to malformed XML, the error message will include the line number and details. However, the error message does not include the file name. This can make troubleshooting difficult when using sysmon-modular with custom modules.

This change adds an error message that displays the file name when the XML file load fails.