### PR TITLE
Create 23 exclusion for Sophos Endpoint journalling temporary files

### DIFF
--- a/23_file_delete/exclude_sophos_journal_temp.xml
+++ b/23_file_delete/exclude_sophos_journal_temp.xml
@@ -1,0 +1,13 @@
+<Sysmon schemaversion="4.30">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+      <FileDelete onmatch="exclude">
+        <TargetFilename condition="begin with">C:\ProgramData\Sophos</TargetFilename>
+        <Rule groupRelation="and">
+          <Image condition="is">C:\Windows\System32\svchost.exe</Image>
+          <TargetFilename condition="end with">.tmp</TargetFilename>
+        </Rule>
+      </FileDelete>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
This exclusion for file deletions corrects a conflict between security log journalling performed by Sophos and Sysmon. This was created from documentation found at https://support.sophos.com/support/s/article/KB-000044827?language=en_US.