### PR TITLE
Add WMI-based Sysmon file archive quota generation

### DIFF
--- a/23_file_delete/interesting_files.xml
+++ b/23_file_delete/interesting_files.xml
@@ -3,6 +3,8 @@
   <EventFiltering>
     <!-- Event ID 23 == File Delete and overwrite events which saves a copy to the archivedir!-->
 	<!-- for specifc extension collection - i've focused on end with for performance.-->
+	<!-- In order to create a Sysmon file archive quota using builtin capabilities; WMI and PowerShell: -->
+	<!-- https://blog.nviso.eu/2022/06/30/enforcing-a-sysmon-archive-quota/ -->
 	<!-- Collect interesting files designed to be used with Velociraptor Sysmon Arcive monitoring/management -->
 	<!-- https://docs.velociraptor.app/exchange/artifacts/pages/sysmonarchive -->
 	<!-- https://docs.velociraptor.app/exchange/artifacts/pages/sysmonarchivemonitor/ -->


### PR DESCRIPTION
This PR includes a comment in `File Delete` events related configuration, for those who uses it. In order to keep the archived files under control without a third party included, utilizing WMI filters and events looks like a reasonable idea.