### PR TITLE
disable blocking download of an executable

### DIFF
--- a/sysmonconfig-research.xml
+++ b/sysmonconfig-research.xml
@@ -69,7 +69,7 @@
 	  <ClipboardChange onmatch="exclude"/>
 	  <ProcessTampering onmatch="exclude"/>
 	  <FileDeleteDetected onmatch="exclude"/>
-	  <FileBlockExecutable onmatch="exclude"/>
+	  <FileBlockExecutable onmatch="include"/>
 	  <FileBlockShredding onmatch="exclude"/>
   </EventFiltering>
 </Sysmon>


### PR DESCRIPTION
This is subjective but imho blocking downloaded executables should be disabled by default and enabled if the researcher wants to. This is to avoid issues like[ #151 ](https://github.com/olafhartong/sysmon-modular/issues/151). 

Event 27 will not only block downloads but also applications that rely on extracting an embedded executable at runtime such as ProcMon, ProcExp and Sysmon itself. Users who have an automated pipeline that will install Sysmon research configuration at the middle in the pipeline will have their pipeline broken because all installations after Sysmon will fail. 

As I said, this is very subjective and some researchers might like to have this enabled by default. An alternative is to update the readme and mention that downloads\installation will fail.