### PR TITLE
included image load of dbghelp.dll or dbgcore.dll

### DIFF
--- a/7_image_load/include_minidumpwritedump.xml
+++ b/7_image_load/include_minidumpwritedump.xml
@@ -1,0 +1,10 @@
+<Sysmon schemaversion="4.30">
+    <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+        <ImageLoad onmatch="include">
+            <ImageLoaded name="technique_id=T1003,technique_name=Credential Dumping" condition="contains any">dbghelp.dll;dbgcore.dll</ImageLoaded>	<!--https://github.com/SigmaHQ/sigma/blob/master/rules/windows/image_load/image_load_dll_dbghelp_dbgcore_susp_load.yml--> 
+        </ImageLoad>
+      </RuleGroup>
+    </EventFiltering>
+  </Sysmon>
+  


### PR DESCRIPTION
Included image load of dbghelp.dll or dbgcore.dll because credential dumper tools often abuses MiniDumpWriteDump API found in dbghelp.dll or dbgcore.dll for credential dumping purposes.