### PR TITLE
Improving Sysmon config parsing

### DIFF
--- a/Merge-SysmonXml.ps1
+++ b/Merge-SysmonXml.ps1
@@ -748,7 +748,7 @@ $mdeaugmentlog = [xml]@'
 
     foreach($key in $Rules.Keys){
         foreach($config in $Source,$Diff){
-            foreach($rule in $config.SelectNodes("//RuleGroup/$Key"))
+            foreach($rule in $config.SelectNodes("//$Key"))
             {
                 $clone = $rule.CloneNode($true)
                 $onmatch = ([System.Xml.XmlElement]$clone).GetAttribute('onmatch')

--- a/merge_sysmon_configs.py
+++ b/merge_sysmon_configs.py
@@ -118,20 +118,20 @@ def merge_sysmon_configs(file_list: List[Dict[str, Union[str, int]]], force_grou
             except Exception as e:
                 logging.exception(f"Error parsing version {version} in file {file_path}, skipping file")
                 continue
-            rule_group = tree.find(".//RuleGroup")
-            if force_grouprelation_or:
-                rule_group.set("groupRelation","or")
-            for event in rule_group:
-                event_type = event.tag
-                onmatch = event.get("onmatch")
-                key = (event_type, onmatch)
+            for rule_group in tree.find("./EventFiltering"):
+                if force_grouprelation_or:
+                    rule_group.set("groupRelation","or")
+                for event in rule_group:
+                    event_type = event.tag
+                    onmatch = event.get("onmatch")
+                    key = (event_type, onmatch)
 
-                if key not in event_dict:
-                    event_dict[key] = event
-                    merged_event_filtering.append(rule_group)
-                else:
-                    for child in event:
-                        event_dict[key].append(child)
+                    if key not in event_dict:
+                        event_dict[key] = event
+                        merged_event_filtering.append(rule_group)
+                    else:
+                        for child in event:
+                            event_dict[key].append(child)
         else:
             logging.warning(f"Provided invalid path {file_path}, will not be merged")
 

--- a/merge_sysmon_configs.py
+++ b/merge_sysmon_configs.py
@@ -119,9 +119,17 @@ def merge_sysmon_configs(file_list: List[Dict[str, Union[str, int]]], force_grou
                 logging.exception(f"Error parsing version {version} in file {file_path}, skipping file")
                 continue
             for rule_group in tree.find("./EventFiltering"):
-                if force_grouprelation_or:
-                    rule_group.set("groupRelation","or")
-                for event in rule_group:
+                rules = []
+                if rule_group.tag == 'RuleGroup':
+                    if force_grouprelation_or:
+                        rule_group.set("groupRelation","or")
+                    rules = rule_group.findall('./')
+                else:
+                    rules = [rule_group]
+                    rule_group = etree.Element("RuleGroup", groupRelation='or')
+                    for rule in rules:
+                        rule_group.append(rule)
+                for event in rules:
                     event_type = event.tag
                     onmatch = event.get("onmatch")
                     key = (event_type, onmatch)


### PR DESCRIPTION
## Issues
1) Python code for merging sysmon configs only considers one RuleGroup
For example, merging the following two configs would result in an incomplete output config:
```
<Sysmon schemaversion="4.90">
    <HashAlgorithms>sha256</HashAlgorithms>
    <CheckRevocation>False</CheckRevocation>
    <EventFiltering>
        <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\System32\cmd.exe</Image>
            </ProcessCreate>
        </RuleGroup>
        <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\SysWOW64\wscript.exe</Image>
            </ProcessCreate>
        </RuleGroup>
    </EventFiltering>
</Sysmon>
```
and
```
<Sysmon schemaversion="4.90">
    <HashAlgorithms>sha256</HashAlgorithms>
    <CheckRevocation>False</CheckRevocation>
    <EventFiltering>
        <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Image>
            </ProcessCreate>
        </RuleGroup>
    </EventFiltering>
</Sysmon>
```
would result in the following merge when using `merge_sysmon_configs.py`:
```
<Sysmon schemaversion="4.90">
    <HashAlgorithms>sha256</HashAlgorithms>
    <CheckRevocation>False</CheckRevocation>
    <EventFiltering>
       <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\System32\cmd.exe</Image>
            </ProcessCreate>
        </RuleGroup>
        <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Image>
            </ProcessCreate>
        </RuleGroup>
    </EventFiltering>
</Sysmon>
```
Note that it misses the rule that includes `C:\Windows\SysWOW64\wscript.exe` because the second rule group wasn't processed.
2) Both Python and PowerShell implementations for merging configs don't consider the case when rules are outside of the rule group.
The following config is also considered valid:
```
<Sysmon schemaversion="4.90">
    <HashAlgorithms>sha256</HashAlgorithms>
    <CheckRevocation>False</CheckRevocation>
    <EventFiltering>
        <ProcessCreate onmatch="include">
            <Image condition="is">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Image>
        </ProcessCreate>
    </EventFiltering>
</Sysmon>
```
Note that it doesn't have the `RuleGroup` - this is equivalent to having the rules inside `<RuleGroup groupRelation="or">`
When trying to merge with such config, the following error is thrown:
![Screenshot 2024-05-03 at 19 40 40](https://github.com/olafhartong/sysmon-modular/assets/8766163/67341d34-1394-4c6e-9c2d-d91f479895d3)

## Desired result
In both cases, the final merged config should look like this (in my opinion):
```
<Sysmon schemaversion="4.90">
    <HashAlgorithms>sha256</HashAlgorithms>
    <CheckRevocation>False</CheckRevocation>
    <EventFiltering>
        <RuleGroup groupRelation="or">
            <ProcessCreate onmatch="include">
                <Image condition="is">C:\Windows\System32\cmd.exe</Image>
                <Image condition="is">C:\Windows\SysWOW64\wscript.exe</Image>
                <Image condition="is">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Image>
            </ProcessCreate>
        </RuleGroup>
    </EventFiltering>
</Sysmon>
```

## Proposed solutions
1) Loop over all children of EventFiltering - 7bad2d9447132842b36bc81825ea120e3925646e
2) Treat non-RuleGroup tags inside EventFiltering as rules - 6480a032213d32d2966fb59197d08fe3ff2b8847 and 3735be978f61aef8c920626aff0f3d9d56e70ab7

### Comment
Since there is no concrete specification for the Sysmon config, this way of merging is my interpretation of how it should be, however, I might be wrong, so I am open to different opinions :)