### PR TITLE
Adding .jse extension to include_javascript.xml

### DIFF
--- a/11_file_create/include_javascript.xml
+++ b/11_file_create/include_javascript.xml
@@ -4,6 +4,7 @@
       <FileCreate onmatch="include">
         <TargetFilename name="technique_id=T1059.007,technique_name=JavaScript" condition="end with">.js</TargetFilename>        <!--Scripting-->
         <TargetFilename name="technique_id=T1059.007,technique_name=JavaScript" condition="end with">.javascript</TargetFilename>        <!--Scripting-->
+        <TargetFilename name="technique_id=T1059.007,technique_name=JavaScript" condition="end with">.jse</TargetFilename>  <!--JScript Encoded-->
       </FileCreate>
     </RuleGroup>
   </EventFiltering>


### PR DESCRIPTION
Adding .JSE extension to include_javascript.xml 

JSE or JScript Encoded files will run by default on Windows machines using Microsoft's JScript scripting engine. This allows for code execution on the machine.

https://filesec.io/jse