### PR TITLE
fix incorrection logic exclusion for Powershell PipeEvent

### DIFF
--- a/17_18_pipe_event/include_powershell.xml
+++ b/17_18_pipe_event/include_powershell.xml
@@ -4,12 +4,8 @@
       <PipeEvent onmatch="include">
         <Rule groupRelation="and">
           <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
-          <Image condition="is not">powershell.exe</Image>
-        </Rule>
-        <Rule groupRelation="and">
-          <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
-          <Image condition="is not">powershell_ise.exe</Image>
-        </Rule>        
+          <Image condition="excludes any">powershell.exe;powershell_ise.exe</Image>
+        </Rule>      
       </PipeEvent>
     </RuleGroup>
   </EventFiltering>


### PR DESCRIPTION
The rules in the file 17_18_pipe_event/include_powershell.xml cancel each other.
`
        <Rule groupRelation="and">
          <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
          <Image condition="is not">powershell.exe</Image>
        </Rule>
`
`
        <Rule groupRelation="and">
          <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
          <Image condition="is not">powershell_ise.exe</Image>
        </Rule>  
`
For instance, a pipe created and names PsHost by powershell.exe :
- won't be included by Rule 1 because of the "is not" powershell
- but will be included by Rule 2 because it is not "powershell_ise.exe".