### PR TITLE
Fix some typo

### DIFF
--- a/12_13_14_registry_event/include_office_dde.xml
+++ b/12_13_14_registry_event/include_office_dde.xml
@@ -4,9 +4,9 @@
 			<RegistryEvent onmatch="include">
 				<!--Microsoft:Office:Security _features-->
 				<!--https://msrc.microsoft.com/update-guide/vulnerability/ADV170021-->
-				<TargetObject name="T1559.002,office" condition="end with">\Word\Security\AllowDDE</TargetObject> 
-				<TargetObject name="T1559.002,office" condition="end with">\Excel\Security\DisableDDEServerLaunch</TargetObject>
-				<TargetObject name="T1559.002,office" condition="end with">\Excel\Security\DisableDDEServerLookup</TargetObject> 		
+				<TargetObject name="technique_id=T1559.002,office" condition="end with">\Word\Security\AllowDDE</TargetObject> 
+				<TargetObject name="technique_id=T1559.002,office" condition="end with">\Excel\Security\DisableDDEServerLaunch</TargetObject>
+				<TargetObject name="technique_id=T1559.002,office" condition="end with">\Excel\Security\DisableDDEServerLookup</TargetObject> 		
 			</RegistryEvent>
 		</RuleGroup>
 	</EventFiltering>

--- a/12_13_14_registry_event/include_office_security_features.xml
+++ b/12_13_14_registry_event/include_office_security_features.xml
@@ -4,10 +4,10 @@
 			<RegistryEvent onmatch="include">
 				<!--Microsoft:Office:Security _features-->
 				<!--https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry_event/sysmon_disable_microsoft_office_security_features.yml-->
-				<TargetObject name="T1562,office" condition="end with">\VBAWarnings</TargetObject> 
-				<TargetObject name="T1562,office" condition="end with">\DisableInternetFilesInPV</TargetObject>
-				<TargetObject name="T1562,office" condition="end with">\DisableUnsafeLocationsInPV</TargetObject> 
-				<TargetObject name="T1562,office" condition="end with">\DisableAttachementsInPV</TargetObject>				
+				<TargetObject name="technique_id=T1562,office" condition="end with">\VBAWarnings</TargetObject> 
+				<TargetObject name="technique_id=T1562,office" condition="end with">\DisableInternetFilesInPV</TargetObject>
+				<TargetObject name="technique_id=T1562,office" condition="end with">\DisableUnsafeLocationsInPV</TargetObject> 
+				<TargetObject name="technique_id=T1562,office" condition="end with">\DisableAttachementsInPV</TargetObject>				
 			</RegistryEvent>
 		</RuleGroup>
 	</EventFiltering>

--- a/17_18_pipe_event/include_cobaltstrike.xml
+++ b/17_18_pipe_event/include_cobaltstrike.xml
@@ -7,7 +7,7 @@
         <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="end with">-server</PipeName>        <!-- default cobalt strike pipe name-->
         </Rule>
         <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\msagent_</PipeName>        <!-- default cobalt strike pipe name-->
-        <PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs." condition="begin with">\postex_</PipeName>        <!-- default cobalt strike pipe name-->
+        <PipeName name="technique_id=T1055,Possible Cobalt Strike post-exploitation jobs." condition="begin with">\postex_</PipeName>        <!-- default cobalt strike pipe name-->
         <PipeName name="technique_id=T1021.004,technique_name=Remote Services: SSH" condition="begin with">\postex_ssh_</PipeName>        <!-- default cobalt strike pipe name-->
         <PipeName name="technique_id=T1021.002,technique_name=SMB/Windows Admin Shares" condition="begin with">\status_</PipeName>        <!-- default cobalt strike pipe name-->
       </PipeEvent>

--- a/17_18_pipe_event/include_powershell.xml
+++ b/17_18_pipe_event/include_powershell.xml
@@ -4,12 +4,8 @@
       <PipeEvent onmatch="include">
         <Rule groupRelation="and">
           <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
-          <Image condition="is not">powershell.exe</Image>
-        </Rule>
-        <Rule groupRelation="and">
-          <PipeName name="technique_id=T1059.001,technique_name=PowerShell" condition="begin with">\PSHost</PipeName>
-          <Image condition="is not">powershell_ise.exe</Image>
-        </Rule>        
+          <Image condition="excludes any">powershell.exe;powershell_ise.exe</Image>
+        </Rule>      
       </PipeEvent>
     </RuleGroup>
   </EventFiltering>


### PR DESCRIPTION
Some rule names with a technique_id did not have the prefix tehcnique_id :
12_13_14_registry_event/include_office_dde.xml:  <TargetObject name="T1559.002,office"

fix only line with a ; instead of a , :
<PipeName name="technique_id=T1055; Possible Cobalt Strike post-exploitation jobs."