### PR TITLE
More ps script policy test exclusion

### DIFF
--- a/11_file_create/exclude_psscriptpolicytest.xml
+++ b/11_file_create/exclude_psscriptpolicytest.xml
@@ -11,6 +11,11 @@
                <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
                <User condition="is">NT AUTHORITY\SYSTEM</User>
             </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+               <User condition="is">NT AUTHORITY\SYSTEM</User>
+            </Rule>
          </FileCreate>
       </RuleGroup>
    </EventFiltering>

--- a/11_file_create/exclude_psscriptpolicytest_user.xml
+++ b/11_file_create/exclude_psscriptpolicytest_user.xml
@@ -1,0 +1,16 @@
+<Sysmon schemaversion="4.30">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileCreate onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+         </FileCreate>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>

--- a/23_file_delete/exclude_psscriptpolicytest.xml
+++ b/23_file_delete/exclude_psscriptpolicytest.xml
@@ -1,0 +1,22 @@
+<Sysmon schemaversion="4.60">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileDelete onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\wsmprovhost.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+               <User condition="is">NT AUTHORITY\SYSTEM</User>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+               <User condition="is">NT AUTHORITY\SYSTEM</User>
+            </Rule>
+         </FileDelete>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>

--- a/23_file_delete/exclude_psscriptpolicytest_user.xml
+++ b/23_file_delete/exclude_psscriptpolicytest_user.xml
@@ -1,0 +1,16 @@
+<Sysmon schemaversion="4.60">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileDelete onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+         </FileDelete>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>

--- a/26_file_delete_detected/exclude_psscriptpolicytest.xml
+++ b/26_file_delete_detected/exclude_psscriptpolicytest.xml
@@ -1,0 +1,22 @@
+<Sysmon schemaversion="4.60">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileDeleteDetected onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\wsmprovhost.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+               <User condition="is">NT AUTHORITY\SYSTEM</User>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Windows\Temp;__PSScriptPolicyTest;.ps1</TargetFilename>
+               <User condition="is">NT AUTHORITY\SYSTEM</User>
+            </Rule>
+         </FileDeleteDetected>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>

--- a/26_file_delete_detected/exclude_psscriptpolicytest_user.xml
+++ b/26_file_delete_detected/exclude_psscriptpolicytest_user.xml
@@ -1,0 +1,16 @@
+<Sysmon schemaversion="4.60">
+   <EventFiltering>
+      <RuleGroup name="" groupRelation="or">
+         <FileDeleteDetected onmatch="exclude">
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+            <Rule groupRelation="and">
+               <Image condition="is">C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe</Image> 
+               <TargetFilename condition="contains all">C:\Users\;\AppData\Local\Temp\;__PSScriptPolicyTest;.ps1</TargetFilename>
+            </Rule>
+         </FileDeleteDetected>
+      </RuleGroup>
+   </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
I added some more exclusion for PSScriptPolicyTest files.

For event 11, i added a file to exclude thoses files created under : C:\Users\*\AppData\Local\Temp\__PSScriptPolicyTest_*.ps1

For event 23 and 26, i added two config files to exclude files legitimately deleted under :

- C:\Users\*\AppData\Local\Temp\__PSScriptPolicyTest_*.ps1
- C:\Windows\Temp\*__PSScriptPolicyTest*.ps1