### PR TITLE
Update include_all.xml

### DIFF
--- a/1_process_creation/include_all.xml
+++ b/1_process_creation/include_all.xml
@@ -3,7 +3,7 @@
         <RuleGroup name="" groupRelation="or">
             <ProcessCreate onmatch="include">
                 <!-- Include All -->
-                <OriginalFileName condition="contains">\</OriginalFileName>
+                <Image condition="contains">\</Image>
             </ProcessCreate>
         </RuleGroup>
     </EventFiltering>


### PR DESCRIPTION
OriginalFileName does not contain a \ as it is not a path but the name of the executable, and event 1 will not be produced.
Image is a path and a \ will be a true include all.