### PR TITLE
Add Sysmon Rule: Certutil Abuse Detection (T1105)

### DIFF
--- a/1_process_creation/include_certutil_abuse.xml
+++ b/1_process_creation/include_certutil_abuse.xml
@@ -1,0 +1,10 @@
+<RuleGroup name="Certutil Abuse" groupRelation="or">
+  <ProcessCreate onmatch="include">
+    <CommandLine condition="contains">certutil</CommandLine>
+    <CommandLine condition="contains">-urlcache</CommandLine>
+  </ProcessCreate>
+  <ProcessCreate onmatch="include">
+    <CommandLine condition="contains">certutil</CommandLine>
+    <CommandLine condition="contains">-decode</CommandLine>
+  </ProcessCreate>
+</RuleGroup>


### PR DESCRIPTION
This adds a new Sysmon rule to detect malicious use of certutil with the -urlcache and -decode flags.

Both options are known to be abused by attackers to download and decode payloads during the early stages of an intrusion. The rule uses process creation (Event ID 1) and matches common patterns seen in real-world tradecraft.

File: include_certutil_abuse.xml  
MITRE Technique: T1105 – Ingress Tool Transfer